### PR TITLE
rename exported trace to gotrace

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -192,7 +192,7 @@ void goredump(void) {
 
 int mill_tracelevel = 0;
 
-void trace(int level) {
+void gotrace(int level) {
     mill_tracelevel = level;
 }
 
@@ -232,6 +232,6 @@ void mill_preserve_debug(void) {
     if(unoptimisable)
         return;
     goredump();
-    trace(0);
+    gotrace(0);
 }
 

--- a/libmill.h
+++ b/libmill.h
@@ -272,7 +272,7 @@ MILL_EXPORT void tcpclose(tcpsock s);
 /******************************************************************************/
 
 MILL_EXPORT void goredump(void);
-MILL_EXPORT void trace(int level);
+MILL_EXPORT void gotrace(int level);
 
 #endif
 

--- a/tests/choose.c
+++ b/tests/choose.c
@@ -107,7 +107,7 @@ void unused(void) {
 int main() {
     /* In this test we are also going to make sure that the debugging support
        doesn't crash the application. */
-    trace(1);
+    gotrace(1);
 
     /* Non-blocking receiver case. */
     chan ch1 = chmake(int, 0);


### PR DESCRIPTION
`libmill.h` exports a `void trace(int)`.

apple's xcode system uses lib ncurses' `trace`, so it's a type collision on my compiler.

can we rename `trace` to `mtrace`?