### PR TITLE
avoid redefinition of typedef error on llvm

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -252,7 +252,7 @@ MILL_EXPORT void *mill_choose_val(void);
 /*  TCP library                                                               */
 /******************************************************************************/
 
-typedef struct tcpsock *tcpsock;
+typedef struct mill_tcpsock *tcpsock;
 
 MILL_EXPORT tcpsock tcplisten(const char *addr, int port);
 MILL_EXPORT int tcpport(tcpsock s);

--- a/tcp.c
+++ b/tcp.c
@@ -66,18 +66,18 @@ enum mill_tcptype {
    MILL_TCPCONN
 };
 
-struct tcpsock {
+struct mill_tcpsock {
     enum mill_tcptype type;
 };
 
 struct tcplistener {
-    struct tcpsock sock;
+    struct mill_tcpsock sock;
     int fd;
     int port;
 };
 
 struct tcpconn {
-    struct tcpsock sock;
+    struct mill_tcpsock sock;
     int fd;
     int ifirst;
     int ilen;


### PR DESCRIPTION
when binding to libmill from node.js (basically a C++ environment), i got:
```c++
error: typedef redefinition with different types ('struct tcpsock *' vs 'tcpsock')
```
the proposed change avoids the problem, allowing me to bind to libmill