### PR TITLE
add fd helper: returns descriptor

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -256,6 +256,7 @@ typedef struct mill_tcpsock *tcpsock;
 
 MILL_EXPORT tcpsock tcplisten(const char *addr, int port);
 MILL_EXPORT int tcpport(tcpsock s);
+MILL_EXPORT int tcpfd(tcpsock s);
 MILL_EXPORT tcpsock tcpaccept(tcpsock s, int64_t deadline);
 MILL_EXPORT tcpsock tcpconnect(const char *addr, int port, int64_t deadline);
 MILL_EXPORT size_t tcpsend(tcpsock s, const void *buf, size_t len,

--- a/tcp.c
+++ b/tcp.c
@@ -204,6 +204,16 @@ int tcpport(tcpsock s) {
     return l->port;
 }
 
+int tcpfd(tcpsock s) {
+    if (s->type == MILL_TCPLISTENER) {
+      struct mill_tcplistener *l = (struct mill_tcplistener*)s;
+      return l->fd;
+    } else {
+      struct mill_tcpconn *c = (struct mill_tcpconn*)s;
+      return c->fd;
+    }
+}
+
 tcpsock tcpaccept(tcpsock s, int64_t deadline) {
     if(s->type != MILL_TCPLISTENER)
         mill_panic("trying to accept on a socket that isn't listening");


### PR DESCRIPTION
similar to the `tcpport(s)` helper, you pass it a mill `tcpsock s` to get its `fd`:
```c
int tcpfd(tcpsock s);
```

