### PR TITLE
Unix socket support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ libmill_la_SOURCES = \
     stack.c\
     tcp.c\
     udp.c\
+    unix.c\
     utils.h\
     utils.c\
     valbuf.h\
@@ -82,7 +83,8 @@ check_PROGRAMS = \
     tests/sleep\
     tests/fdwait\
     tests/tcp\
-    tests/udp
+    tests/udp\
+    tests/unix
 
 LDADD = libmill.la
 

--- a/libmill.h
+++ b/libmill.h
@@ -285,6 +285,24 @@ MILL_EXPORT size_t udprecv(udpsock s, udpaddr *addr,
 MILL_EXPORT void udpclose(udpsock s);
 
 /******************************************************************************/
+/*  UNIX library                                                               */
+/******************************************************************************/
+
+typedef struct mill_unixsock *unixsock;
+
+MILL_EXPORT unixsock unixlisten(const char *addr);
+MILL_EXPORT unixsock unixaccept(unixsock s, int64_t deadline);
+MILL_EXPORT unixsock unixconnect(const char *addr, int64_t deadline);
+MILL_EXPORT size_t unixsend(unixsock s, const void *buf, size_t len,
+    int64_t deadline);
+MILL_EXPORT void unixflush(unixsock s, int64_t deadline);
+MILL_EXPORT size_t unixrecv(unixsock s, void *buf, size_t len,
+    int64_t deadline);
+MILL_EXPORT size_t unixrecvuntil(unixsock s, void *buf, size_t len,
+    unsigned char until, int64_t deadline);
+MILL_EXPORT void unixclose(unixsock s);
+
+/******************************************************************************/
 /*  Debugging                                                                 */
 /******************************************************************************/
 

--- a/tests/unix.c
+++ b/tests/unix.c
@@ -1,0 +1,94 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../libmill.h"
+
+void client(const char *addr) {
+    unixsock cs = unixconnect(addr, -1);
+    assert(cs);
+
+    msleep(now() + 100);
+
+    char buf[16];
+    size_t sz = unixrecv(cs, buf, 3, -1);
+    assert(sz == 3 && buf[0] == 'A' && buf[1] == 'B' && buf[2] == 'C');
+
+    sz = unixsend(cs, "123\n45\n6789", 11, -1);
+    assert(sz == 11 && errno == 0);
+    unixflush(cs, -1);
+    assert(errno == 0);
+
+    unixclose(cs);
+}
+
+int main() {
+    const char *sockname = "milltest.sock";
+    char buf[16];
+    struct stat st;
+
+    if (stat(sockname, &st) == 0) {
+        assert(unlink(sockname) == 0);
+    }
+
+    unixsock ls = unixlisten(sockname);
+    assert(ls);
+
+    go(client(sockname));
+
+    unixsock as = unixaccept(ls, -1);
+
+    /* Test deadline. */
+    int64_t deadline = now() + 30;
+    size_t sz = unixrecv(as, buf, sizeof(buf), deadline);
+    assert(sz == 0 && errno == ETIMEDOUT);
+    int64_t diff = now() - deadline;
+    assert(diff > -10 && diff < 10);
+
+    sz = unixsend(as, "ABC", 3, -1);
+    assert(sz == 3 && errno == 0);
+    unixflush(as, -1);
+    assert(errno == 0);
+
+    sz = unixrecvuntil(as, buf, sizeof(buf), '\n', -1);
+    assert(sz == 4);
+    assert(buf[0] == '1' && buf[1] == '2' && buf[2] == '3' && buf[3] == '\n');
+    sz = unixrecvuntil(as, buf, sizeof(buf), '\n', -1);
+    assert(sz == 3);
+    assert(buf[0] == '4' && buf[1] == '5' && buf[2] == '\n');
+    sz = unixrecvuntil(as, buf, 3, '\n', -1);
+    assert(sz == 3);
+    assert(buf[0] == '6' && buf[1] == '7' && buf[2] == '8');
+
+    unixclose(as);
+    unixclose(ls);
+    unlink(sockname);
+
+    return 0;
+}
+

--- a/unix.c
+++ b/unix.c
@@ -1,0 +1,399 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "libmill.h"
+#include "utils.h"
+
+#define MILL_UNIX_LISTEN_BACKLOG 10
+#define MILL_UNIX_BUFLEN (4096)
+
+enum mill_unixtype {
+   MILL_UNIXLISTENER,
+   MILL_UNIXCONN
+};
+
+struct mill_unixsock {
+    enum mill_unixtype type;
+};
+
+struct mill_unixlistener {
+    struct mill_unixsock sock;
+    int fd;
+};
+
+struct mill_unixconn {
+    struct mill_unixsock sock;
+    int fd;
+    int ifirst;
+    int ilen;
+    int olen;
+    char ibuf[MILL_UNIX_BUFLEN];
+    char obuf[MILL_UNIX_BUFLEN];
+};
+
+static void mill_unixtune(int s) {
+    /* Make the socket non-blocking. */
+    int opt = fcntl(s, F_GETFL, 0);
+    if (opt == -1)
+        opt = 0;
+    int rc = fcntl(s, F_SETFL, opt | O_NONBLOCK);
+    mill_assert(rc != -1);
+    /* If possible, prevent SIGPIPE signal when writing to the connection
+        already closed by the peer. */
+#ifdef SO_NOSIGPIPE
+    opt = 1;
+    rc = setsockopt (s, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof (opt));
+    mill_assert (rc == 0 || errno == EINVAL);
+#endif
+}
+
+static int mill_unixresolve(const char *addr, struct sockaddr_un *su) {
+    mill_assert(su);
+    if (strlen(addr) >= sizeof(su->sun_path)) {
+        errno = EINVAL;
+        return -1;
+    }
+    su->sun_family = AF_UNIX;
+    strncpy(su->sun_path, addr, sizeof(su->sun_path));
+    errno = 0;
+    return 0;
+}
+
+static struct mill_unixconn *unixconn_create(int fd) {
+    struct mill_unixconn *conn = malloc(sizeof(struct mill_unixconn));
+    mill_assert(conn);
+    conn->sock.type = MILL_UNIXCONN;
+    conn->fd = fd;
+    conn->ifirst = 0;
+    conn->ilen = 0;
+    conn->olen = 0;
+    return conn;
+}
+
+unixsock unixlisten(const char *addr) {
+    struct sockaddr_un su;
+    int rc = mill_unixresolve(addr, &su);
+    if (rc != 0) {
+        return NULL;
+    }
+    /* Open the listening socket. */
+    int s = socket(AF_UNIX, SOCK_STREAM, 0);
+    if(s == -1)
+        return NULL;
+    mill_unixtune(s);
+
+    /* Start listening. */
+    rc = bind(s, (struct sockaddr*)&su, sizeof(struct sockaddr_un));
+    if(rc != 0)
+        return NULL;
+    rc = listen(s, MILL_UNIX_LISTEN_BACKLOG);
+    if(rc != 0)
+        return NULL;
+
+    /* Create the object. */
+    struct mill_unixlistener *l = malloc(sizeof(struct mill_unixlistener));
+    mill_assert(l);
+    l->sock.type = MILL_UNIXLISTENER;
+    l->fd = s;
+    errno = 0;
+    return &l->sock;
+}
+
+unixsock unixaccept(unixsock s, int64_t deadline) {
+    if(s->type != MILL_UNIXLISTENER)
+        mill_panic("trying to accept on a socket that isn't listening");
+    struct mill_unixlistener *l = (struct mill_unixlistener*)s;
+    while(1) {
+        /* Try to get new connection (non-blocking). */
+        int as = accept(l->fd, NULL, NULL);
+        if (as >= 0) {
+            mill_unixtune(as);
+            errno = 0;
+            return &unixconn_create(as)->sock;
+        }
+        mill_assert(as == -1);
+        if(errno != EAGAIN && errno != EWOULDBLOCK)
+            return NULL;
+        /* Wait till new connection is available. */
+        int rc = fdwait(l->fd, FDW_IN, deadline);
+        if(rc == 0) {
+            errno = ETIMEDOUT;
+            return NULL;
+        }
+        mill_assert(rc == FDW_IN);
+    }
+}
+
+unixsock unixconnect(const char *addr, int64_t deadline) {
+    struct sockaddr_un su;
+    int rc = mill_unixresolve(addr, &su);
+    if (rc != 0) {
+        return NULL;
+    }
+
+    /* Open a socket. */
+    int s = socket(AF_UNIX,  SOCK_STREAM, 0);
+    if(s == -1)
+        return NULL;
+    mill_unixtune(s);
+
+    /* Connect to the remote endpoint. */
+    rc = connect(s, (struct sockaddr*)&su, sizeof(struct sockaddr_un));
+    if(rc != 0) {
+        mill_assert(rc == -1);
+        if(errno != EINPROGRESS)
+            return NULL;
+        rc = fdwait(s, FDW_OUT, deadline);
+        if(rc == 0) {
+            errno = ETIMEDOUT;
+            return NULL;
+        }
+        int err;
+        socklen_t errsz = sizeof(err);
+        rc = getsockopt(s, SOL_SOCKET, SO_ERROR, (void*)&err, &errsz);
+        if(rc != 0) {
+            err = errno;
+            close(s);
+            errno = err;
+            return NULL;
+        }
+        if(err != 0) {
+            close(s);
+            errno = err;
+            return NULL;
+        }
+    }
+
+    /* Create the object. */
+    errno = 0;
+    return &unixconn_create(s)->sock;
+}
+
+size_t unixsend(unixsock s, const void *buf, size_t len, int64_t deadline) {
+    if(s->type != MILL_UNIXCONN)
+        mill_panic("trying to send to an unconnected socket");
+    struct mill_unixconn *conn = (struct mill_unixconn*)s;
+
+    /* If it fits into the output buffer copy it there and be done. */
+    if(conn->olen + len <= MILL_UNIX_BUFLEN) {
+        memcpy(&conn->obuf[conn->olen], buf, len);
+        conn->olen += len;
+        errno = 0;
+        return len;
+    }
+
+    /* If it doesn't fit, flush the output buffer first. */
+    unixflush(s, deadline);
+    if(errno != 0)
+        return 0;
+
+    /* Try to fit it into the buffer once again. */
+    if(conn->olen + len <= MILL_UNIX_BUFLEN) {
+        memcpy(&conn->obuf[conn->olen], buf, len);
+        conn->olen += len;
+        errno = 0;
+        return len;
+    }
+
+    /* The data chunk to send is longer than the output buffer.
+       Let's do the sending in-place. */
+    char *pos = (char*)buf;
+    size_t remaining = len;
+    while(remaining) {
+        ssize_t sz = send(conn->fd, pos, remaining, 0);
+        if(sz == -1) {
+            if(errno != EAGAIN && errno != EWOULDBLOCK)
+                return 0;
+            int rc = fdwait(conn->fd, FDW_OUT, deadline);
+            if(rc == 0) {
+                errno = ETIMEDOUT;
+                return len - remaining;
+            }
+            mill_assert(rc == FDW_OUT);
+            continue;
+        }
+        pos += sz;
+        remaining -= sz;
+    }
+    return len;
+}
+
+void unixflush(unixsock s, int64_t deadline) {
+    if(s->type != MILL_UNIXCONN)
+        mill_panic("trying to send to an unconnected socket");
+    struct mill_unixconn *conn = (struct mill_unixconn*)s;
+    if(!conn->olen) {
+        errno = 0;
+        return;
+    }
+    char *pos = conn->obuf;
+    size_t remaining = conn->olen;
+    while(remaining) {
+        ssize_t sz = send(conn->fd, pos, remaining, 0);
+        if(sz == -1) {
+            if(errno != EAGAIN && errno != EWOULDBLOCK)
+                return;
+            int rc = fdwait(conn->fd, FDW_OUT, deadline);
+            if(rc == 0) {
+                errno = ETIMEDOUT;
+                return;
+            }
+            mill_assert(rc == FDW_OUT);
+            continue;
+        }
+        pos += sz;
+        remaining -= sz;
+    }
+    conn->olen = 0;
+    errno = 0;
+}
+
+size_t unixrecv(unixsock s, void *buf, size_t len, int64_t deadline) {
+    if(s->type != MILL_UNIXCONN)
+        mill_panic("trying to receive from an unconnected socket");
+    struct mill_unixconn *conn = (struct mill_unixconn*)s;
+    /* If there's enough data in the buffer it's easy. */
+    if(conn->ilen >= len) {
+        memcpy(buf, &conn->ibuf[conn->ifirst], len);
+        conn->ifirst += len;
+        conn->ilen -= len;
+        errno = 0;
+        return len;
+    }
+
+    /* Let's move all the data from the buffer first. */
+    char *pos = (char*)buf;
+    size_t remaining = len;
+    memcpy(pos, &conn->ibuf[conn->ifirst], conn->ilen);
+    pos += conn->ilen;
+    remaining -= conn->ilen;
+    conn->ifirst = 0;
+    conn->ilen = 0;
+
+    mill_assert(remaining);
+    while(1) {
+        if(remaining > MILL_UNIX_BUFLEN) {
+            /* If we still have a lot to read try to read it in one go directly
+               into the destination buffer. */
+            ssize_t sz = recv(conn->fd, pos, remaining, 0);
+            if(!sz) {
+                errno = ECONNRESET;
+                return len - remaining;
+            }
+            if(sz == -1) {
+                if(errno != EAGAIN && errno != EWOULDBLOCK)
+                    return len - remaining;
+                sz = 0;
+            }
+            if(sz == remaining) {
+                errno = 0;
+                return len;
+            }
+            pos += sz;
+            remaining -= sz;
+        }
+        else {
+            /* If we have just a little to read try to read the full connection
+               buffer to minimise the number of system calls. */
+            ssize_t sz = recv(conn->fd, conn->ibuf, MILL_UNIX_BUFLEN, 0);
+            if(!sz) {
+                errno = ECONNRESET;
+                return len - remaining;
+            }
+            if(sz == -1) {
+                if(errno != EAGAIN && errno != EWOULDBLOCK)
+                    return len - remaining;
+                sz = 0;
+            }
+            if(sz < remaining) {
+                memcpy(pos, conn->ibuf, sz);
+                pos += sz;
+                remaining -= sz;
+                conn->ifirst = 0;
+                conn->ilen = 0;
+            }
+            else {
+                memcpy(pos, conn->ibuf, remaining);
+                conn->ifirst = remaining;
+                conn->ilen = sz - remaining;
+                errno = 0;
+                return len;
+            }
+        }
+
+        /* Wait till there's more data to read. */
+        int res = fdwait(conn->fd, FDW_IN, deadline);
+        if(!res) {
+            errno = ETIMEDOUT;
+            return len - remaining;
+        }
+        mill_assert(res & FDW_IN);
+    }
+}
+
+size_t unixrecvuntil(unixsock s, void *buf, size_t len, unsigned char until,
+      int64_t deadline) {
+    if(s->type != MILL_UNIXCONN)
+        mill_panic("trying to receive from an unconnected socket");
+    unsigned char *pos = (unsigned char*)buf;
+    size_t i;
+    for(i = 0; i != len; ++i, ++pos) {
+        size_t res = unixrecv(s, pos, 1, deadline);
+        if(res == 1 && *pos == until)
+            return i + 1;
+        if (errno != 0)
+            return i + res;
+    }
+    errno = ENOBUFS;
+    return len;
+}
+
+void unixclose(unixsock s) {
+    if(s->type == MILL_UNIXLISTENER) {
+        struct mill_unixlistener *l = (struct mill_unixlistener*)s;
+        int rc = close(l->fd);
+        mill_assert(rc == 0);
+        free(l);
+        return;
+    }
+    if(s->type == MILL_UNIXCONN) {
+        struct mill_unixconn *c = (struct mill_unixconn*)s;
+        int rc = close(c->fd);
+        mill_assert(rc == 0);
+        free(c);
+        return;
+    }
+    mill_assert(0);
+}
+


### PR DESCRIPTION
This is mostly c&p form tcp. By having a common fd+buffer struct the *recv/send functions could be unified.

There is a small API issue (if you care about linux abstract unix domain sockets that is). Abstract socket names start with 0 byte and that doesn't work well with the single char* addr argument we have now.