### PR TITLE
Remove deadline from unixconnect

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -292,7 +292,7 @@ typedef struct mill_unixsock *unixsock;
 
 MILL_EXPORT unixsock unixlisten(const char *addr);
 MILL_EXPORT unixsock unixaccept(unixsock s, int64_t deadline);
-MILL_EXPORT unixsock unixconnect(const char *addr, int64_t deadline);
+MILL_EXPORT unixsock unixconnect(const char *addr);
 MILL_EXPORT size_t unixsend(unixsock s, const void *buf, size_t len,
     int64_t deadline);
 MILL_EXPORT void unixflush(unixsock s, int64_t deadline);

--- a/tests/unix.c
+++ b/tests/unix.c
@@ -30,7 +30,7 @@
 #include "../libmill.h"
 
 void client(const char *addr) {
-    unixsock cs = unixconnect(addr, -1);
+    unixsock cs = unixconnect(addr);
     assert(cs);
 
     msleep(now() + 100);

--- a/unix.c
+++ b/unix.c
@@ -155,7 +155,7 @@ unixsock unixaccept(unixsock s, int64_t deadline) {
     }
 }
 
-unixsock unixconnect(const char *addr, int64_t deadline) {
+unixsock unixconnect(const char *addr) {
     struct sockaddr_un su;
     int rc = mill_unixresolve(addr, &su);
     if (rc != 0) {
@@ -172,27 +172,8 @@ unixsock unixconnect(const char *addr, int64_t deadline) {
     rc = connect(s, (struct sockaddr*)&su, sizeof(struct sockaddr_un));
     if(rc != 0) {
         mill_assert(rc == -1);
-        if(errno != EINPROGRESS)
-            return NULL;
-        rc = fdwait(s, FDW_OUT, deadline);
-        if(rc == 0) {
-            errno = ETIMEDOUT;
-            return NULL;
-        }
-        int err;
-        socklen_t errsz = sizeof(err);
-        rc = getsockopt(s, SOL_SOCKET, SO_ERROR, (void*)&err, &errsz);
-        if(rc != 0) {
-            err = errno;
-            close(s);
-            errno = err;
-            return NULL;
-        }
-        if(err != 0) {
-            close(s);
-            errno = err;
-            return NULL;
-        }
+        close(s);
+        return NULL;
     }
 
     /* Create the object. */


### PR DESCRIPTION
EINPROGRESS doesn't happen.

Alternatively we could handle EAGAIN and repeatedly try connect() until the
deadline is reached.