### PR TITLE
Assert that fd is found in pollset after suspend

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -135,6 +135,7 @@ int mill_fdwait(int fd, int events, int64_t deadline, const char *current) {
         /* We have to do this again because the pollset may have changed while
            the coroutine was suspended. */
         int i = mill_find_pollset(fd);
+        mill_assert(i < mill_pollset_size);
         if(mill_pollset_items[i].in == &mill_running->u_fdwait) {
             mill_pollset_items[i].in = NULL;
             mill_pollset_fds[i].events &= ~POLLIN;


### PR DESCRIPTION
After suspend, the fd should be in the pollset. If it is not there this
must be a bug.

Add an assert that make the intent clear and fail loudly if this
assumption is wrong.

Submitted under MIT license.
Signed-off-by: Nir Soffer <nsoffer@redhat.com>