### PR TITLE
Abort on panic

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -38,8 +38,7 @@ static mach_timebase_info_data_t mill_mtid = {0};
 
 void mill_panic(const char *text) {
     fprintf(stderr, "panic: %s\n", text);
-    fflush(stderr);
-    exit(1);
+    abort();
 }
 
 int64_t now(void) {


### PR DESCRIPTION
Currently we exit cleanly in mill_panic, loosing all state. Replace
exit() with abort(), creating a helpful core dump.

Submitted under MIT license.    
Signed-off-by: Nir Soffer <nsoffer@redhat.com>
