### PR TITLE
Use consistent with end of line terminator

### DIFF
--- a/tutorial/step2.c
+++ b/tutorial/step2.c
@@ -47,11 +47,11 @@ int main(int argc, char *argv[]) {
         tcpflush(as, -1);
 
         char inbuf[256];
-        size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r", 1, -1);
+        size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r\n", 2, -1);
 
         inbuf[sz - 1] = 0;
         char outbuf[256];
-        int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\n", inbuf);
+        int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\r\n", inbuf);
 
         sz = tcpsend(as, outbuf, rc, -1);
         tcpflush(as, -1);

--- a/tutorial/step3.c
+++ b/tutorial/step3.c
@@ -53,13 +53,13 @@ int main(int argc, char *argv[]) {
             goto cleanup;
 
         char inbuf[256];
-        size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r", 1, -1);
+        size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r\n", 2, -1);
         if(errno != 0)
             goto cleanup;
 
         inbuf[sz - 1] = 0;
         char outbuf[256];
-        int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\n", inbuf);
+        int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\r\n", inbuf);
 
         sz = tcpsend(as, outbuf, rc, -1);
         if(errno != 0)

--- a/tutorial/step4.c
+++ b/tutorial/step4.c
@@ -37,13 +37,13 @@ void dialogue(tcpsock as) {
         goto cleanup;
 
     char inbuf[256];
-    size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r", 1, -1);
+    size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r\n", 2, -1);
     if(errno != 0)
         goto cleanup;
 
     inbuf[sz - 1] = 0;
     char outbuf[256];
-    int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\n", inbuf);
+    int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\r\n", inbuf);
 
     sz = tcpsend(as, outbuf, rc, -1);
     if(errno != 0)

--- a/tutorial/step5.c
+++ b/tutorial/step5.c
@@ -39,13 +39,13 @@ void dialogue(tcpsock as) {
         goto cleanup;
 
     char inbuf[256];
-    size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r", 1, deadline);
+    size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r\n", 2, deadline);
     if(errno != 0)
         goto cleanup;
 
     inbuf[sz - 1] = 0;
     char outbuf[256];
-    int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\n", inbuf);
+    int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\r\n", inbuf);
 
     sz = tcpsend(as, outbuf, rc, deadline);
     if(errno != 0)

--- a/tutorial/step6.c
+++ b/tutorial/step6.c
@@ -66,13 +66,13 @@ void dialogue(tcpsock as, chan ch) {
         goto cleanup;
 
     char inbuf[256];
-    size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r", 1, deadline);
+    size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r\n", 2, deadline);
     if(errno != 0)
         goto cleanup;
 
     inbuf[sz - 1] = 0;
     char outbuf[256];
-    int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\n", inbuf);
+    int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\r\n", inbuf);
 
     sz = tcpsend(as, outbuf, rc, deadline);
     if(errno != 0)


### PR DESCRIPTION
The tutorial used to accept CR LF when receiving data, but sent LF. Now
we always use CR LF.

Submitted under MIT license.
Signed-off-by: Nir Soffer <nsoffer@redhat.com>