### PR TITLE
Add failing test for scheduling channels

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,8 @@ check_PROGRAMS = \
     tests/tcp\
     tests/udp\
     tests/unix\
-    tests/signals
+    tests/signals\
+    tests/sched
 
 LDADD = libmill.la
 

--- a/tests/sched.c
+++ b/tests/sched.c
@@ -1,0 +1,53 @@
+/*
+
+  Copyright (c) 2015 Nir Soffer
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include "../libmill.h"
+
+#include <assert.h>
+#include <unistd.h>
+
+void relay(chan src, chan dst) {
+    while(1) {
+       int val = chr(src, int);
+       chs(dst, int, val);
+    }
+}
+
+int main() {
+    chan left = chmake(int, 0);
+    chan right = chmake(int, 0);
+
+    go(relay(left, right));
+    go(relay(right, left));
+
+    chs(left, int, 42);
+
+    /* Fail with exit code 128+SIGALRM if we deadlock */
+    alarm(1);
+
+    msleep(now() + 100);
+
+    return 0;
+}
+


### PR DESCRIPTION
When running ping-pong over two channels, msleep() will not wake up. Add
a test reproducing this issue.

Submitted under MIT license.
Signed-off-by: Nir Soffer <nsoffer@redhat.com>