### PR TITLE
print test-suite.log on travis after fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 
 after_failure:
   - for f in tests/*.log; do echo; echo "${f}:"; cat $f; done;
+  - cat test-suite.log
 
 notifications:
   email: false


### PR DESCRIPTION
looking at #83's travis tests happening now, i think we should `cat` the test-suite.log

if one day it's green on one OS but not the other, this way at least the report shows on travis 