### PR TITLE
Add optional stack guard page

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,17 @@ if test "x$enable_debug" = "xyes"; then
 fi
 
 ################################################################################
+#  --enable-stack-guard                                                        #
+################################################################################
+AC_ARG_ENABLE([stack-guard], [AS_HELP_STRING([--enable-stack-guard],
+    [Enable guard page in goroutine stacks [default=no]])])
+
+
+if test "x$enable_stack_guard" = "xyes"; then
+	AC_CHECK_FUNC([posix_memalign], [], [AC_MSG_ERROR(posix_memalign is required for stack guard.)])
+	AC_DEFINE([MILL_ENABLE_STACK_GUARD], [1], [])
+fi
+################################################################################
 #  Feature checks.                                                             #
 ################################################################################
 


### PR DESCRIPTION
Compiling with -DMILL_ENABLE_STACK_GUARD=1 will mark the first
page of each goroutine stack as PROT_NONE. Not sure if it makes sense to
enable this by default, but it certainly makes it easier to debug stack
overflows.