### PR TITLE
Partial OpenBSD support

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -157,7 +157,12 @@ void mill_freestack(void *stack) {
        Standard C free() is not required to work when it deallocates its
        own stack from underneath itself. Instead, we'll deallocate one of
        the unused cached stacks. */
-    item = mill_slist_pop(&mill_cached_stacks);  
-    free(((char*)(item + 1)) - mill_get_stack_size());
+    item = mill_slist_pop(&mill_cached_stacks);
+    void *ptr = ((char*)(item + 1)) - mill_get_stack_size();
+#if HAVE_POSIX_MEMALIGN && HAVE_MPROTECT
+    int rc = mprotect(ptr, mill_page_size(), PROT_READ|PROT_WRITE);
+    mill_assert(rc == 0);
+#endif
+    free(ptr);
 }
 

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -57,7 +57,7 @@ int main() {
     tcpsock ls = tcplisten(iplocal(NULL, 5555, 0), 10);
     assert(ls);
 
-#if !defined __APPLE__
+#if !defined __APPLE__ && !defined __OpenBSD__
     int fd = tcpdetach(ls);
     assert(fd != -1);
     ls = tcpattach(fd);

--- a/tests/unix.c
+++ b/tests/unix.c
@@ -64,7 +64,7 @@ int main() {
     unixsock ls = unixlisten(sockname, 10);
     assert(ls);
 
-#if !defined __APPLE__
+#if !defined __APPLE__ && !defined __OpenBSD__
     int fd = unixdetach(ls);
     assert(fd != -1);
     ls = unixattach(fd);


### PR DESCRIPTION
- the base system gcc (4.2) doesn't have `__COUNTER__` support, but
clang from ports works.
- free() does a memset, so the stack guard has to be removed before calling it.
- SO_ACCEPTCON isn't supported so these tests are disabled.