### PR TITLE
Add listening arg to tcp/unixattach

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -291,7 +291,7 @@ MILL_EXPORT size_t tcprecv(tcpsock s, void *buf, size_t len, int64_t deadline);
 MILL_EXPORT size_t tcprecvuntil(tcpsock s, void *buf, size_t len,
     const char *delims, size_t delimcount, int64_t deadline);
 MILL_EXPORT void tcpclose(tcpsock s);
-MILL_EXPORT tcpsock tcpattach(int fd);
+MILL_EXPORT tcpsock tcpattach(int fd, int listening);
 MILL_EXPORT int tcpdetach(tcpsock s);
 
 /******************************************************************************/
@@ -327,7 +327,7 @@ MILL_EXPORT size_t unixrecv(unixsock s, void *buf, size_t len,
 MILL_EXPORT size_t unixrecvuntil(unixsock s, void *buf, size_t len,
     const char *delims, size_t delimcount, int64_t deadline);
 MILL_EXPORT void unixclose(unixsock s);
-MILL_EXPORT unixsock unixattach(int fd);
+MILL_EXPORT unixsock unixattach(int fd, int listening);
 MILL_EXPORT int unixdetach(unixsock s);
 
 /******************************************************************************/

--- a/tcp.c
+++ b/tcp.c
@@ -429,17 +429,8 @@ void tcpclose(tcpsock s) {
     mill_assert(0);
 }
 
-tcpsock tcpattach(int fd) {
-    int val;
-    socklen_t sz = sizeof(val);
-    int rc = getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &sz);
-    if(rc == -1 && errno == ENOPROTOOPT) {
-        val = 0;
-    }
-    else if(rc != 0) {
-        return NULL;
-    }
-    if(val == 0) {
+tcpsock tcpattach(int fd, int listening) {
+    if(listening == 0) {
         struct mill_tcpconn *conn = malloc(sizeof(struct mill_tcpconn));
         if(!conn) {
             errno = ENOMEM;
@@ -451,8 +442,8 @@ tcpsock tcpattach(int fd) {
     }
     /* It's a listening socket. Find out the port it is listening on. */
     ipaddr addr;
-    sz = sizeof(ipaddr);
-    rc = getsockname(fd, (struct sockaddr*)&addr, &sz);
+    socklen_t sz = sizeof(ipaddr);
+    int rc = getsockname(fd, (struct sockaddr*)&addr, &sz);
     if(rc == -1)
         return NULL;
     struct mill_tcplistener *l = malloc(sizeof(struct mill_tcplistener));

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -34,7 +34,7 @@ coroutine void client(int port) {
 
     int fd = tcpdetach(cs);
     assert(fd != -1);
-    cs = tcpattach(fd);
+    cs = tcpattach(fd, 0);
     assert(cs);
 
     msleep(now() + 100);
@@ -57,13 +57,11 @@ int main() {
     tcpsock ls = tcplisten(iplocal(NULL, 5555, 0), 10);
     assert(ls);
 
-#if !defined __APPLE__ && !defined __OpenBSD__
     int fd = tcpdetach(ls);
     assert(fd != -1);
-    ls = tcpattach(fd);
+    ls = tcpattach(fd, 1);
     assert(ls);
     assert(tcpport(ls) == 5555);
-#endif
 
     go(client(5555));
 

--- a/tests/unix.c
+++ b/tests/unix.c
@@ -35,7 +35,7 @@ coroutine void client(const char *addr) {
 
     int fd = unixdetach(cs);
     assert(fd != -1);
-    cs = unixattach(fd);
+    cs = unixattach(fd, 0);
     assert(cs);
 
     msleep(now() + 100);
@@ -64,12 +64,10 @@ int main() {
     unixsock ls = unixlisten(sockname, 10);
     assert(ls);
 
-#if !defined __APPLE__ && !defined __OpenBSD__
     int fd = unixdetach(ls);
     assert(fd != -1);
-    ls = unixattach(fd);
+    ls = unixattach(fd, 1);
     assert(ls);
-#endif
 
     go(client(sockname));
 

--- a/unix.c
+++ b/unix.c
@@ -432,17 +432,8 @@ void unixclose(unixsock s) {
     mill_assert(0);
 }
 
-unixsock unixattach(int fd) {
-    int val;
-    socklen_t sz = sizeof(val);
-    int rc = getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &sz);
-    if(rc == -1 && errno == ENOPROTOOPT) {
-        val = 0;
-    }
-    else if(rc != 0) {
-        return NULL;
-    }
-    if(val == 0) {
+unixsock unixattach(int fd, int listening) {
+    if(listening == 0) {
         struct mill_unixconn *conn = malloc(sizeof(struct mill_unixconn));
         if(!conn) {
             errno = ENOMEM;


### PR DESCRIPTION
SO_ACCEPTCONN does not work on a lot of system, so add an explicit argument to
tcp/unixattach.

Tests now pass on OpenBSD, NetBSD and DragonFly.

Fixes #108 

