### PR TITLE
Fix tcprecvuntil

### DIFF
--- a/tcp.c
+++ b/tcp.c
@@ -398,11 +398,9 @@ size_t tcprecvuntil(tcpsock s, void *buf, size_t len,
     size_t i;
     for(i = 0; i != len; ++i, ++pos) {
         size_t res = tcprecv(s, pos, 1, deadline);
-        if(res == 1) {
-            size_t j;
-            for(j = 0; j != delimcount; ++j)
-                if(*pos == delims[j])
-                    return i + 1;
+        if(res == 1 && (i + 1) >= delimcount) {
+            if(memcmp(pos - delimcount + 1, delims, delimcount) == 0)
+                return i;
         }
         if (errno != 0)
             return i + res;

--- a/tcp.c
+++ b/tcp.c
@@ -400,7 +400,7 @@ size_t tcprecvuntil(tcpsock s, void *buf, size_t len,
         size_t res = tcprecv(s, pos, 1, deadline);
         if(res == 1 && (i + 1) >= delimcount) {
             if(memcmp(pos - delimcount + 1, delims, delimcount) == 0)
-                return i;
+                return i + 1;
         }
         if (errno != 0)
             return i + res;

--- a/tutorial/step2.c
+++ b/tutorial/step2.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
         char inbuf[256];
         size_t sz = tcprecvuntil(as, inbuf, sizeof(inbuf), "\r\n", 2, -1);
 
-        inbuf[sz - 1] = 0;
+        inbuf[sz - 2] = 0;
         char outbuf[256];
         int rc = snprintf(outbuf, sizeof(outbuf), "Hello, %s!\r\n", inbuf);
 


### PR DESCRIPTION
It will return to caller, when the "pos" point to the first char in "delims", but not continue to do the matching.

For example.  the recv buffer is "sdf\rsdfsdf\r\nsdf", and the delims is "\r\n".
the original implement will fill the buf with "sdf\r", but not "sdf\rsdfsdf\r\n".

corresponding, step2.c  should be fixed