### PR TITLE
convert ip address string from sockaddr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ branches:
     - master
 
 install:
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CC=gcc-4.8; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then mkdir m4 && export CC=gcc-4.8; fi
   - if [[ $CMAKE == "false" ]]; then ./autogen.sh && ./configure && make; fi
   - if [[ $CMAKE == "true"  ]]; then cmake . && make; fi
 

--- a/ip.c
+++ b/ip.c
@@ -149,6 +149,18 @@ int mill_ipport(ipaddr addr) {
         ((struct sockaddr_in6*)&addr)->sin6_port);
 }
 
+/* Convert IP address from network format to ASCII dot notation. */
+const char *ipaddrstr(ipaddr addr, char *ipstr) {
+    if (mill_ipfamily(addr) == AF_INET) {
+        return inet_ntop(AF_INET, &(((struct sockaddr_in*)&addr)->sin_addr),
+            ipstr, INET_ADDRSTRLEN);
+    }
+    else {
+        return inet_ntop(AF_INET6, &(((struct sockaddr_in6*)&addr)->sin6_addr),
+            ipstr, INET6_ADDRSTRLEN);
+    }
+}
+
 ipaddr iplocal(const char *name, int port, int mode) {
     if(!name)
         return mill_ipany(port, mode);

--- a/libmill.h
+++ b/libmill.h
@@ -267,12 +267,14 @@ MILL_EXPORT void *mill_choose_val(size_t sz);
 #define IPADDR_IPV6 2
 #define IPADDR_PREF_IPV4 3
 #define IPADDR_PREF_IPV6 4
+#define IPADDR_MAXSTRLEN 46
 
 typedef struct {char data[32];} ipaddr;
 
 MILL_EXPORT ipaddr iplocal(const char *name, int port, int mode);
 MILL_EXPORT ipaddr ipremote(const char *name, int port, int mode,
     int64_t deadline);
+MILL_EXPORT const char *ipaddrstr(ipaddr addr, char *ipstr);
 
 /******************************************************************************/
 /*  TCP library                                                               */

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -24,6 +24,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "../libmill.h"
 
@@ -31,6 +32,11 @@ coroutine void client(int port) {
     ipaddr addr = ipremote("127.0.0.1", port, 0, -1);
     tcpsock cs = tcpconnect(addr, -1);
     assert(cs);
+
+    char ipstr[16] = {0};
+    ipaddrstr(addr, ipstr);
+    assert(errno == 0);
+    assert(strcmp(ipstr, "127.0.0.1") == 0);
 
     int fd = tcpdetach(cs);
     assert(fd != -1);
@@ -72,7 +78,7 @@ int main() {
     size_t sz = tcprecv(as, buf, sizeof(buf), deadline);
     assert(sz == 0 && errno == ETIMEDOUT);
     int64_t diff = now() - deadline;
-    assert(diff > -20 && diff < 20); 
+    assert(diff > -20 && diff < 20);
 
     sz = tcpsend(as, "ABC", 3, -1);
     assert(sz == 3 && errno == 0);

--- a/tests/udp.c
+++ b/tests/udp.c
@@ -24,6 +24,8 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "../libmill.h"
 
@@ -38,18 +40,27 @@ int main() {
     s2 = udpattach(fd);
     assert(s2);
 
+    char ipstr[IPADDR_MAXSTRLEN] = {0};
+    ipaddrstr(ipremote("216.58.217.46", 5556, 0, -1), ipstr);
+    assert(errno == 0);
+    assert(strcmp(ipstr, "216.58.217.46") == 0);
+
     ipaddr addr = ipremote("127.0.0.1", 5556, 0, -1);
 
     while(1) {
         udpsend(s1, addr, "ABC", 3);
         assert(errno == 0);
-        
+
         char buf[3];
         size_t sz = udprecv(s2, &addr, buf, sizeof(buf), now() + 100);
         if(errno == ETIMEDOUT)
             continue;
         assert(errno == 0);
         assert(sz == 3);
+
+        ipaddrstr(addr, ipstr);
+        assert(errno == 0);
+        assert(strcmp(ipstr, "127.0.0.1") == 0);
         break;
     }
 
@@ -63,6 +74,10 @@ int main() {
             continue;
         assert(errno == 0);
         assert(sz == 3);
+
+        ipaddrstr(addr, ipstr);
+        assert(errno == 0);
+        assert(strcmp("127.0.0.1", ipstr) == 0);
         break;
     }
 


### PR DESCRIPTION
not sure if this implementation is acceptable nor whether it should go in the IP Address or UDP Library, but I think exporting something to this affect from `libmill.h` would be rather useful.

With udprecv on datagram packets, we pass `ipaddr *addr` pointer
```c
size_t udprecv(udpsock s, ipaddr *addr, void *buf, size_t len, int64_t deadline);
```
While this returns a size_t of the inbound packet, the `ipaddr *addr` pointer is also allocated like an `ipaddr ipremote()` for origin, and we can use the allocated pointer to send data back to client. 

If we need to establish different category protocol connections to origin or to holepunch clients, before we're done we can extract sender's public IP Address string from datagram's `ipaddr addr`:

~~`char *udpaddr(ipaddr addr);`~~
```c
char *ipaddrstr(ipaddr addr);
```
`char *ipaddrstr()` converts allocated `ipaddr *addr` struct from network format to ASCII dot notation. 
* returns NULL if a system error occurs, in which case errno will have been set, or
* returns a pointer to human readable IP address string (numbers and dots)
* responsibility to `free()` allocated string rests upon udpaddr() caller