### PR TITLE
Explicitly don't save signal mask with setjmp.

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -36,8 +36,8 @@ struct mill_ctx {
     jmp_buf jbuf;
 };
 
-#define mill_setjmp(ctx) setjmp((ctx)->jbuf)
-#define mill_jmp(ctx) longjmp((ctx)->jbuf, 1)
+#define mill_setjmp(ctx) sigsetjmp((ctx)->jbuf, 0)
+#define mill_jmp(ctx) siglongjmp((ctx)->jbuf, 1)
 
 /* Cause panic. */
 void mill_panic(const char *text);


### PR DESCRIPTION
OS X (and possibly other BSD descendants) do save sigmask by default with `setjmp` and cause about a 7x slowdown. Seems modern linux doesn't unless specific compatibility defines are present.

I made a perf test that is a variant of whisper.c but more in line with standard message passing tests used in erlang go typically.

See:

C: https://gist.github.com/banks/ed49cfeb176842302441
Go: https://gist.github.com/banks/f825baf42ed44cd3e648

Before I was seeing about 7x slower for the C variant with all optimisations enabled under OS X and clang.

This patch brings libmill perf back into same ballpark (marginally quicker usually on my machine) as go.

If it's valuable, I'm happy to contribute the gist above as an additional performance test (or a replacement to whisper.c) for the repo.

I've not yet tested this under other OS/compiler/architectures although, from what I've read, I believe it to be as portable as the current supported OS list for libmill.

This contribution is made under the MIT license.