### PR TITLE
mill_tcpconn add member ipaddr

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -295,6 +295,8 @@ MILL_EXPORT size_t tcprecvuntil(tcpsock s, void *buf, size_t len,
 MILL_EXPORT void tcpclose(tcpsock s);
 MILL_EXPORT tcpsock tcpattach(int fd, int listening);
 MILL_EXPORT int tcpdetach(tcpsock s);
+MILL_EXPORT ipaddr tcpconnip(tcpsock s);
+
 
 /******************************************************************************/
 /*  UDP library                                                               */

--- a/tcp.c
+++ b/tcp.c
@@ -146,10 +146,15 @@ tcpsock tcplisten(ipaddr addr, int backlog) {
 }
 
 int tcpport(tcpsock s) {
-    if(s->type != MILL_TCPLISTENER)
-        mill_panic("trying to get port from a socket that isn't listening");
-    struct mill_tcplistener *l = (struct mill_tcplistener*)s;
-    return l->port;
+    if(s->type == MILL_TCPCONN) {
+        struct mill_tcpconn *c = (struct mill_tcpconn*)s;
+        return mill_ipport(c->addr);
+    }
+    else if(s->type == MILL_TCPLISTENER) {
+        struct mill_tcplistener *l = (struct mill_tcplistener*)s;
+        return l->port;
+    }
+    mill_assert(0);
 }
 
 tcpsock tcpaccept(tcpsock s, int64_t deadline) {
@@ -478,10 +483,9 @@ int tcpdetach(tcpsock s) {
     mill_assert(0);
 }
 
-ipaddr tcpconnip(tcpsock s)
-{
+ipaddr tcpconnip(tcpsock s) {
     if(s->type != MILL_TCPCONN)
-		mill_panic("trying to get ipaddr from a socket that isn't connected");
+        mill_panic("trying to get ipaddr from a socket that isn't connected");
     struct mill_tcpconn *l = (struct mill_tcpconn *)s;
     return l->addr;
 }

--- a/tcp.c
+++ b/tcp.c
@@ -69,6 +69,7 @@ struct mill_tcpconn {
     size_t olen;
     char ibuf[MILL_TCP_BUFLEN];
     char obuf[MILL_TCP_BUFLEN];
+    ipaddr addr;
 };
 
 static void mill_tcptune(int s) {
@@ -97,6 +98,7 @@ static void tcpconn_init(struct mill_tcpconn *conn, int fd) {
     conn->ifirst = 0;
     conn->ilen = 0;
     conn->olen = 0;
+	memset(&conn->addr,0,sizeof(ipaddr));
 }
 
 tcpsock tcplisten(ipaddr addr, int backlog) {
@@ -155,9 +157,12 @@ tcpsock tcpaccept(tcpsock s, int64_t deadline) {
     if(s->type != MILL_TCPLISTENER)
         mill_panic("trying to accept on a socket that isn't listening");
     struct mill_tcplistener *l = (struct mill_tcplistener*)s;
+    socklen_t addrlen;
+    ipaddr addr;
     while(1) {
         /* Try to get new connection (non-blocking). */
-        int as = accept(l->fd, NULL, NULL);
+        addrlen = sizeof(addr);
+        int as = accept(l->fd, (struct sockaddr *)&addr, &addrlen);
         if (as >= 0) {
             mill_tcptune(as);
             struct mill_tcpconn *conn = malloc(sizeof(struct mill_tcpconn));
@@ -167,6 +172,7 @@ tcpsock tcpaccept(tcpsock s, int64_t deadline) {
                 return NULL;
             }
             tcpconn_init(conn, as);
+            conn->addr = addr;
             errno = 0;
             return (tcpsock)conn;
         }
@@ -472,4 +478,14 @@ int tcpdetach(tcpsock s) {
     }
     mill_assert(0);
 }
+
+
+ipaddr tcpconnip(tcpsock s)
+{
+    if(s->type != MILL_TCPCONN)
+		mill_panic("trying to get ipaddr from a socket that isn't connected");
+    struct mill_tcpconn *l = (struct mill_tcpconn *)s;
+    return l->addr;
+}
+
 

--- a/tcp.c
+++ b/tcp.c
@@ -98,7 +98,6 @@ static void tcpconn_init(struct mill_tcpconn *conn, int fd) {
     conn->ifirst = 0;
     conn->ilen = 0;
     conn->olen = 0;
-	memset(&conn->addr,0,sizeof(ipaddr));
 }
 
 tcpsock tcplisten(ipaddr addr, int backlog) {
@@ -479,7 +478,6 @@ int tcpdetach(tcpsock s) {
     mill_assert(0);
 }
 
-
 ipaddr tcpconnip(tcpsock s)
 {
     if(s->type != MILL_TCPCONN)
@@ -487,5 +485,4 @@ ipaddr tcpconnip(tcpsock s)
     struct mill_tcpconn *l = (struct mill_tcpconn *)s;
     return l->addr;
 }
-
 

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -72,6 +72,11 @@ int main() {
     go(client(5555));
 
     tcpsock as = tcpaccept(ls, -1);
+	/* Test client ipaddr */
+	ipaddr addr = tcpconnip(as);
+	char ipstr[IPADDR_MAXSTRLEN];
+	ipaddrstr(addr,ipstr);
+	assert(strcmp(ipstr, "127.0.0.1") == 0);
 
     /* Test deadline. */
     int64_t deadline = now() + 30;

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -72,11 +72,12 @@ int main() {
     go(client(5555));
 
     tcpsock as = tcpaccept(ls, -1);
-	/* Test client ipaddr */
-	ipaddr addr = tcpconnip(as);
-	char ipstr[IPADDR_MAXSTRLEN];
-	ipaddrstr(addr,ipstr);
-	assert(strcmp(ipstr, "127.0.0.1") == 0);
+    /* Test client ipaddr */
+    ipaddr addr = tcpconnip(as);
+    char ipstr[IPADDR_MAXSTRLEN];
+    ipaddrstr(addr,ipstr);
+    assert(strcmp(ipstr, "127.0.0.1") == 0);
+    assert(tcpport(as) != 5555);
 
     /* Test deadline. */
     int64_t deadline = now() + 30;


### PR DESCRIPTION
Hi,Sometimes we need to know the client's ip or port,For example,connection from 127.0.0.1 can pass the server,but 221.xx.xx.xx cann't,Or the port range from 1000~2000 can pass,others should Refuse(like a firewall).
So I add a ipaddr struct in mill_tcpconn,Use tcpconnip(tcpsock s) function can get the connection ip info.
 