### PR TITLE
add file wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ tests/overload
 tests/ip
 tests/*.trs
 tests/*.log
+tests/file
 perf/.dirstamp
 perf/go
 perf/ctxswitch

--- a/AUTHORS
+++ b/AUTHORS
@@ -13,7 +13,7 @@ Nick Desaulniers <nick@mozilla.com>
 Nir Soffer <nsoffer@redhat.com> *
 Paul Banks <banks@banksdesigns.co.uk>
 Yue Xu <red_angelx@qq.com>
-Paulo Faria <paulo.faria.rl@gmail.com>
+Paulo Faria <paulo@zewo.io>
 
 * Future patches by this author are submitted under MIT/X11 license
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Nick Desaulniers <nick@mozilla.com>
 Nir Soffer <nsoffer@redhat.com> *
 Paul Banks <banks@banksdesigns.co.uk>
 Yue Xu <red_angelx@qq.com>
+Paulo Faria <paulo.faria.rl@gmail.com>
 
 * Future patches by this author are submitted under MIT/X11 license
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,8 @@ libmill_la_SOURCES = \
     epoll.inc \
     kqueue.inc \
     dns/dns.h \
-    dns/dns.c
+    dns/dns.c \
+    file.c
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libmill.pc
@@ -89,7 +90,8 @@ check_PROGRAMS = \
     tests/unix\
     tests/signals\
     tests/overload\
-    tests/ip
+    tests/ip\
+    tests/file
 
 LDADD = libmill.la
 

--- a/file.c
+++ b/file.c
@@ -1,0 +1,289 @@
+/*
+
+  Copyright (c) 2016 Paulo Faria
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "libmill.h"
+#include "utils.h"
+
+#ifndef MILL_FILE_BUFLEN
+#define MILL_FILE_BUFLEN (4096)
+#endif
+
+struct mill_file {
+    int fd;
+    size_t ifirst;
+    size_t ilen;
+    size_t olen;
+    char ibuf[MILL_FILE_BUFLEN];
+    char obuf[MILL_FILE_BUFLEN];
+};
+
+static void mill_filetune(int fd) {
+    /* Make the file descriptor non-blocking. */
+    int opt = fcntl(fd, F_GETFL, 0);
+    if (opt == -1)
+        opt = 0;
+    int rc = fcntl(fd, F_SETFL, opt | O_NONBLOCK);
+    mill_assert(rc != -1);
+}
+
+
+mfile fileopen(const char *pathname, int flags, mode_t mode) {
+    /* Open the file. */
+    int fd = open(pathname, flags, mode);
+    if (fd == -1)
+        return NULL;
+    mill_filetune(fd);
+
+    /* Create the object. */
+    struct mill_file *f = malloc(sizeof(struct mill_file));
+    if(!f) {
+        fdclean(fd);
+        close(fd);
+        errno = ENOMEM;
+        return NULL;
+    }
+    f->fd = fd;
+    f->ifirst = 0;
+    f->ilen = 0;
+    f->olen = 0;
+    errno = 0;
+    return f;
+}
+
+size_t filewrite(mfile f, const void *buf, size_t len, int64_t deadline) {
+    /* If it fits into the output buffer copy it there and be done. */
+    if(f->olen + len <= MILL_FILE_BUFLEN) {
+        memcpy(&f->obuf[f->olen], buf, len);
+        f->olen += len;
+        errno = 0;
+        return len;
+    }
+
+    /* If it doesn't fit, flush the output buffer first. */
+    fileflush(f, deadline);
+    if(errno != 0)
+        return 0;
+
+    /* Try to fit it into the buffer once again. */
+    if(f->olen + len <= MILL_FILE_BUFLEN) {
+        memcpy(&f->obuf[f->olen], buf, len);
+        f->olen += len;
+        errno = 0;
+        return len;
+    }
+
+    /* The data chunk to send is longer than the output buffer.
+     Let's do the writing in-place. */
+    char *pos = (char*)buf;
+    size_t remaining = len;
+    while(remaining) {
+        ssize_t sz = write(f->fd, pos, remaining);
+        if(sz == -1) {
+            if(errno != EAGAIN && errno != EWOULDBLOCK)
+                return 0;
+            int rc = fdwait(f->fd, FDW_OUT, deadline);
+            if(rc == 0) {
+                errno = ETIMEDOUT;
+                return len - remaining;
+            }
+            mill_assert(rc == FDW_OUT);
+            continue;
+        }
+        pos += sz;
+        remaining -= sz;
+    }
+    return len;
+}
+
+void fileflush(mfile f, int64_t deadline) {
+    if(!f->olen) {
+        errno = 0;
+        return;
+    }
+    char *pos = f->obuf;
+    size_t remaining = f->olen;
+    while(remaining) {
+        ssize_t sz = write(f->fd, pos, remaining);
+        if(sz == -1) {
+            if(errno != EAGAIN && errno != EWOULDBLOCK)
+                return;
+            int rc = fdwait(f->fd, FDW_OUT, deadline);
+            if(rc == 0) {
+                errno = ETIMEDOUT;
+                return;
+            }
+            mill_assert(rc == FDW_OUT);
+            continue;
+        }
+        pos += sz;
+        remaining -= sz;
+    }
+    f->olen = 0;
+    errno = 0;
+}
+
+size_t fileread(mfile f, void *buf, size_t len, int64_t deadline) {
+    /* If there's enough data in the buffer it's easy. */
+    if(f->ilen >= len) {
+        memcpy(buf, &f->ibuf[f->ifirst], len);
+        f->ifirst += len;
+        f->ilen -= len;
+        errno = 0;
+        return len;
+    }
+
+    /* Let's move all the data from the buffer first. */
+    char *pos = (char*)buf;
+    size_t remaining = len;
+    memcpy(pos, &f->ibuf[f->ifirst], f->ilen);
+    pos += f->ilen;
+    remaining -= f->ilen;
+    f->ifirst = 0;
+    f->ilen = 0;
+
+    mill_assert(remaining);
+    while(1) {
+        if(remaining > MILL_FILE_BUFLEN) {
+            /* If we still have a lot to read try to read it in one go directly
+             into the destination buffer. */
+            ssize_t sz = read(f->fd, pos, remaining);
+            if(!sz) {
+                return len - remaining;
+            }
+            if(sz == -1) {
+                if(errno != EAGAIN && errno != EWOULDBLOCK)
+                    return len - remaining;
+                sz = 0;
+            }
+            if((size_t)sz == remaining) {
+                errno = 0;
+                return len;
+            }
+            pos += sz;
+            remaining -= sz;
+            if (sz != 0 && fileeof(f)) {
+                return len - remaining;
+            }
+        }
+        else {
+            /* If we have just a little to read try to read the full connection
+             buffer to minimise the number of system calls. */
+            ssize_t sz = read(f->fd, f->ibuf, MILL_FILE_BUFLEN);
+            if(!sz) {
+                return len - remaining;
+            }
+            if(sz == -1) {
+                if(errno != EAGAIN && errno != EWOULDBLOCK)
+                    return len - remaining;
+                sz = 0;
+            }
+            if((size_t)sz < remaining) {
+                memcpy(pos, f->ibuf, sz);
+                pos += sz;
+                remaining -= sz;
+                f->ifirst = 0;
+                f->ilen = 0;
+            }
+            else {
+                memcpy(pos, f->ibuf, remaining);
+                f->ifirst = remaining;
+                f->ilen = sz - remaining;
+                errno = 0;
+                return len;
+            }
+            if (sz != 0 && fileeof(f)) {
+                return len - remaining;
+            }
+        }
+
+        /* Wait till there's more data to read. */
+        int res = fdwait(f->fd, FDW_IN, deadline);
+        if (!res) {
+            errno = ETIMEDOUT;
+            return len - remaining;
+        }
+    }
+}
+
+void fileclose(mfile f) {
+    fdclean(f->fd);
+    int rc = close(f->fd);
+    mill_assert(rc == 0);
+    free(f);
+    return;
+}
+
+mfile fileattach(int fd) {
+    struct mill_file *f = malloc(sizeof(struct mill_file));
+    if(!f) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    int nfd = dup(fd);
+    mill_filetune(nfd);
+    f->fd = nfd;
+    f->ifirst = 0;
+    f->ilen = 0;
+    f->olen = 0;
+    errno = 0;
+    return f;
+}
+
+int filedetach(mfile f) {
+    int fd = f->fd;
+    free(f);
+    return fd;
+}
+
+off_t filetell(mfile f) {
+    return lseek(f->fd, 0, SEEK_CUR) - f->ilen;
+}
+
+off_t fileseek(mfile f, off_t offset) {
+    f->ifirst = 0;
+    f->ilen = 0;
+    f->olen = 0;
+    return lseek(f->fd, offset, SEEK_SET);
+}
+
+int fileeof(mfile f) {
+    off_t current = lseek(f->fd, 0, SEEK_CUR);
+    if (current == -1)
+        return -1;
+    off_t eof = lseek(f->fd, 0, SEEK_END);
+    if (eof == -1)
+        return -1;
+    off_t res = lseek(f->fd, current, SEEK_SET);
+    if (res == -1)
+        return -1;
+    return (current == eof);
+}

--- a/libmill.h
+++ b/libmill.h
@@ -360,16 +360,16 @@ MILL_EXPORT int unixdetach(unixsock s);
 /******************************************************************************/
 
 typedef struct mill_file *mfile;
-MILL_EXPORT mfile fileopen(const char *pathname, int flags, mode_t mode);
-MILL_EXPORT size_t filewrite(mfile f, const void *buf, size_t len, int64_t deadline);
-MILL_EXPORT void fileflush(mfile f, int64_t deadline);
-MILL_EXPORT size_t fileread(mfile f, void *buf, size_t len, int64_t deadline);
-MILL_EXPORT void fileclose(mfile f);
-MILL_EXPORT mfile fileattach(int fd);
-MILL_EXPORT int filedetach(mfile f);
-MILL_EXPORT off_t filetell(mfile f);
-MILL_EXPORT off_t fileseek(mfile f, off_t offset);
-MILL_EXPORT int fileeof(mfile f);
+MILL_EXPORT mfile mfopen(const char *pathname, int flags, mode_t mode);
+MILL_EXPORT size_t mfwrite(mfile f, const void *buf, size_t len, int64_t deadline);
+MILL_EXPORT void mfflush(mfile f, int64_t deadline);
+MILL_EXPORT size_t mfread(mfile f, void *buf, size_t len, int64_t deadline);
+MILL_EXPORT void mfclose(mfile f);
+MILL_EXPORT mfile mfattach(int fd);
+MILL_EXPORT int mfdetach(mfile f);
+MILL_EXPORT off_t mftell(mfile f);
+MILL_EXPORT off_t mfseek(mfile f, off_t offset);
+MILL_EXPORT int mfeof(mfile f);
 
 /******************************************************************************/
 /*  Debugging                                                                 */

--- a/libmill.h
+++ b/libmill.h
@@ -355,6 +355,22 @@ MILL_EXPORT unixsock unixattach(int fd, int listening);
 MILL_EXPORT int unixdetach(unixsock s);
 
 /******************************************************************************/
+/*  File library                                                              */
+/******************************************************************************/
+
+typedef struct mill_file *mfile;
+MILL_EXPORT mfile fileopen(const char *pathname, int flags, mode_t mode);
+MILL_EXPORT size_t filewrite(mfile f, const void *buf, size_t len, int64_t deadline);
+MILL_EXPORT void fileflush(mfile f, int64_t deadline);
+MILL_EXPORT size_t fileread(mfile f, void *buf, size_t len, int64_t deadline);
+MILL_EXPORT void fileclose(mfile f);
+MILL_EXPORT mfile fileattach(int fd);
+MILL_EXPORT int filedetach(mfile f);
+MILL_EXPORT off_t filetell(mfile f);
+MILL_EXPORT off_t fileseek(mfile f, off_t offset);
+MILL_EXPORT int fileeof(mfile f);
+
+/******************************************************************************/
 /*  Debugging                                                                 */
 /******************************************************************************/
 

--- a/libmill.h
+++ b/libmill.h
@@ -29,6 +29,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 /******************************************************************************/
 /*  ABI versioning support                                                    */

--- a/tests/file.c
+++ b/tests/file.c
@@ -1,0 +1,73 @@
+/*
+
+  Copyright (c) 2016 Paulo Faria
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "../libmill.h"
+
+int main() {
+    mfile f1 = fileopen("/tmp/file1", O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    assert(f1);
+
+    int fd = filedetach(f1);
+    assert(fd != -1);
+    f1 = fileattach(fd);
+    assert(f1);
+
+    assert(fileeof(f1));
+    assert(errno == 0);
+
+    filewrite(f1, "ABC", 3, -1);
+    assert(errno == 0);
+
+    fileflush(f1, -1);
+    assert(errno == 0);
+
+    assert(fileeof(f1));
+    assert(errno == 0);
+
+    assert(filetell(f1) == 3);
+    assert(errno == 0);
+
+    fileseek(f1, 0);
+    assert(errno == 0);
+
+    assert(!fileeof(f1));
+    assert(errno == 0);
+
+    char buf[3];
+    size_t sz = fileread(f1, buf, sizeof(buf), -1);
+    assert(errno == 0);
+    assert(sz == 3 && buf[0] == 'A' && buf[1] == 'B' && buf[2] == 'C');
+
+    assert(fileeof(f1));
+    assert(errno == 0);
+
+    fileclose(f1);
+    return 0;
+}

--- a/tests/file.c
+++ b/tests/file.c
@@ -31,43 +31,43 @@
 #include "../libmill.h"
 
 int main() {
-    mfile f1 = fileopen("/tmp/file1", O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    mfile f1 = mfopen("/tmp/file1", O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     assert(f1);
 
-    int fd = filedetach(f1);
+    int fd = mfdetach(f1);
     assert(fd != -1);
-    f1 = fileattach(fd);
+    f1 = mfattach(fd);
     assert(f1);
 
-    assert(fileeof(f1));
+    assert(mfeof(f1));
     assert(errno == 0);
 
-    filewrite(f1, "ABC", 3, -1);
+    mfwrite(f1, "ABC", 3, -1);
     assert(errno == 0);
 
-    fileflush(f1, -1);
+    mfflush(f1, -1);
     assert(errno == 0);
 
-    assert(fileeof(f1));
+    assert(mfeof(f1));
     assert(errno == 0);
 
-    assert(filetell(f1) == 3);
+    assert(mftell(f1) == 3);
     assert(errno == 0);
 
-    fileseek(f1, 0);
+    mfseek(f1, 0);
     assert(errno == 0);
 
-    assert(!fileeof(f1));
+    assert(!mfeof(f1));
     assert(errno == 0);
 
     char buf[3];
-    size_t sz = fileread(f1, buf, sizeof(buf), -1);
+    size_t sz = mfread(f1, buf, sizeof(buf), -1);
     assert(errno == 0);
     assert(sz == 3 && buf[0] == 'A' && buf[1] == 'B' && buf[2] == 'C');
 
-    assert(fileeof(f1));
+    assert(mfeof(f1));
     assert(errno == 0);
 
-    fileclose(f1);
+    mfclose(f1);
     return 0;
 }


### PR DESCRIPTION
Signed-off-by: Paulo Faria <paulo.faria.rl@gmail.com>

I'm not sure about the naming. `mfile` could be named `file`, but I think that's dangerous. The functions could be renamed to `mfopen`, `mfclose`, `mftell`, etc.. though.

Submitted under MIT/X11 license