### PR TITLE
Add a wrapper around shutdown(2).

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -320,6 +320,7 @@ MILL_EXPORT size_t tcprecv(tcpsock s, void *buf, size_t len, int64_t deadline);
 MILL_EXPORT size_t tcprecvuntil(tcpsock s, void *buf, size_t len,
     const char *delims, size_t delimcount, int64_t deadline);
 MILL_EXPORT void tcpclose(tcpsock s);
+MILL_EXPORT void tcpshutdown(tcpsock s);
 
 /******************************************************************************/
 /*  UDP library                                                               */

--- a/tcp.c
+++ b/tcp.c
@@ -448,6 +448,14 @@ void tcpclose(tcpsock s) {
     mill_assert(0);
 }
 
+void tcpshutdown(tcpsock s) {
+    if (s->type != MILL_TCPCONN)
+        mill_panic("trying to shut down a listening socket");
+    struct mill_tcpconn *c = (struct mill_tcpconn*)s;
+    errno = 0;
+    shutdown(c->fd, SHUT_RDWR);
+}
+
 ipaddr tcpaddr(tcpsock s) {
     if(s->type != MILL_TCPCONN)
         mill_panic("trying to get address from a socket that isn't connected");


### PR DESCRIPTION
Unlike `tcpclose()`, `tcpshutdown()` does not deallocate the `tcpsock`, nor does it close the file descriptor. This allows, for example, forcibly closing the connection from one coroutine while another is blocked on `tcprecv()` (which will instantly return with `ECONNRESET`).

(There's also a commit with updated documentation in the gh-pages branch of the same repo.)