### PR TITLE
get rid of logical compare

### DIFF
--- a/tcp.c
+++ b/tcp.c
@@ -119,7 +119,7 @@ tcpsock tcplisten(ipaddr addr, int backlog) {
     /* If the user requested an ephemeral port,
        retrieve the port number assigned by the OS now. */
     int port = mill_ipport(addr);
-    if(!port == 0) {
+    if(port) {
         ipaddr baddr;
         socklen_t len = sizeof(ipaddr);
         rc = getsockname(s, (struct sockaddr*)&baddr, &len);

--- a/udp.c
+++ b/udp.c
@@ -66,7 +66,7 @@ udpsock udplisten(ipaddr addr) {
     /* If the user requested an ephemeral port,
        retrieve the port number assigned by the OS now. */
     int port = mill_ipport(addr);
-    if(!port == 0) {
+    if(port) {
         ipaddr baddr;
         socklen_t len = sizeof(ipaddr);
         rc = getsockname(s, (struct sockaddr*)&baddr, &len);


### PR DESCRIPTION
i think the logical not is only applied to the left hand side of this comparison, so this should be the same check