### PR TITLE
convert anonymous struct to typedef

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -150,9 +150,9 @@ MILL_EXPORT void setcls(void *val);
 /******************************************************************************/
 
 typedef struct mill_chan *chan;
-
-#define MILL_CLAUSELEN (sizeof(struct{void *f1; void *f2; void *f3; void *f4; \
-    void *f5; void *f6; int f7; int f8; int f9;}))
+typedef struct{void *f1; void *f2; void *f3; void *f4; \
+    void *f5; void *f6; int f7; int f8; int f9;} mill_clause;
+#define MILL_CLAUSELEN (sizeof(mill_clause))
 
 #define chmake(type, bufsz) mill_chmake(sizeof(type), bufsz,\
     __FILE__ ":" mill_string(__LINE__))
@@ -384,4 +384,3 @@ MILL_EXPORT void goredump(void);
 MILL_EXPORT void gotrace(int level);
 
 #endif
-


### PR DESCRIPTION
For compatibility with C++ code, convert the anonymous struct used inside the MILL_CLAUSELEN macro `sizeof(struct{...})` to a typedef.

Using `in:' or 'out:' from C++ code inside a `choose` structure
leads to a 'anonymous type cannot be defined in a type specified'
compile time error.

Patch submitted under MIT/X11.

```
(anonymous struct at ./...:46:5)' cannot be defined in a type specifier
    in(ch, int, val):
    ^
./vendor/libmill/libmill.h:221:30: note: expanded from macro 'in'
#define in(chan, type, name) mill_in((chan), type, name, __COUNTER__)
                             ^
./vendor/libmill/libmill.h:207:48: note: expanded from macro
      'mill_in'
            char mill_concat(mill_clause, idx)[MILL_CLAUSELEN];\
                                               ^
./vendor/libmill/libmill.h:154:32: note: expanded from macro
      'MILL_CLAUSELEN'
#define MILL_CLAUSELEN (sizeof(struct{void *f1; void *f2; voi...
```