### PR TITLE
Clobber all registers in context switching for compiler compatibility

### DIFF
--- a/libmill.h
+++ b/libmill.h
@@ -154,9 +154,16 @@ MILL_EXPORT void mill_setcls_(
 
 
 #if defined(__x86_64__)
+#if defined(__AVX__)
+#define MILL_CLOBBER \
+        , "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6", "ymm7",\
+        "ymm8", "ymm9", "ymm10", "ymm11", "ymm12", "ymm13", "ymm14", "ymm15"
+#else
+#define MILL_CLOBBER
+#endif
 #define mill_setjmp_(ctx) ({\
     int ret;\
-    asm ("lea     LJMPRET%=(%%rip), %%rcx\n\t"\
+    asm("lea     LJMPRET%=(%%rip), %%rcx\n\t"\
         "xor     %%rax, %%rax\n\t"\
         "mov     %%rbx, (%%rdx)\n\t"\
         "mov     %%rbp, 8(%%rdx)\n\t"\
@@ -170,7 +177,12 @@ MILL_EXPORT void mill_setcls_(
         "mov     %%rsi, 72(%%rdx)\n\t"\
         "LJMPRET%=:\n\t"\
         : "=a" (ret)\
-        : "d" (ctx) : "memory");\
+        : "d" (ctx)\
+        : "memory", "rcx", "r8", "r9", "r10", "r11",\
+          "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",\
+          "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"\
+          MILL_CLOBBER\
+          );\
     ret;\
 })
 #define mill_longjmp_(ctx) \


### PR DESCRIPTION
Re-introduced the register clobbering in the x86-64 implementation of context switching as clang is less conservative than gcc.